### PR TITLE
fix: disable on localhost by default (with override)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Initialises the Umami tracking plugin with specified options.
         - `websiteID` (String): The Umami website ID required for tracking.
         - `scriptSrc` (String, optional): Custom URL for the Umami script source, default: `https://us.umami.is/script.js`
         - `router` (Router, optional): The Vue Router instance for automatic page tracking.
+        - `allowLocalhost` (Boolean, optional): Whether to allow tracking on localhost, default: `false`
 
 ### `trackUmamiEvent(event, eventParams)`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ type UmamiPluginOptions = {
     websiteID: string;
     scriptSrc?: string;
     router?: Router;
+    allowLocalhost?: boolean;
 }
 
 type UmamiPluginQueuedEvent = {
@@ -30,6 +31,10 @@ const queuedEvents: UmamiPluginQueuedEvent[] = [];
 export function VueUmamiPlugin(options: UmamiPluginOptions): { install: () => void; } {
     return {
         install: () => {
+            if (window.location.hostname.includes('localhost') && !options.allowLocalhost) {
+                console.warn('Umami plugin not installed due to being on localhost.');
+                return;
+            }
             const { scriptSrc = 'https://us.umami.is/script.js', websiteID, router }: UmamiPluginOptions = options;
             if (!websiteID) {
                 return console.warn('Website ID not provided for Umami plugin, skipping.');


### PR DESCRIPTION
Given Umami doesn't allow localhost URLs, I've disabled installing Umami if on localhost, with the parameter `allowLocalhost` to override this behavior.